### PR TITLE
Add new type template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/new-type.yml
+++ b/.github/DISCUSSION_TEMPLATE/new-type.yml
@@ -1,0 +1,50 @@
+title: "Add: "
+labels: ["New type"]
+body:
+- type: input
+  id: name
+  attributes:
+    label: Type name
+    description: The name of the terms type you would like to add.
+    placeholder: Business Privacy Policy
+  validations:
+    required: true
+- type: textarea
+  id: alternative-type-names
+  attributes:
+    label: Alternative type names
+    description: Different names for the same terms type.
+    placeholder: Business Users Privacy Policy, Commercial Privacy Policy
+- type: input
+  id: writer
+  attributes:
+    label: Writer
+    description: The writer of the document, in most cases the service provider itself.
+    placeholder: intermediation service provider
+- type: input
+  id: audience
+  attributes:
+    label: Audience
+    description: The targeted audience whose rights and duties are defined in the associated terms.
+    placeholder: business user
+- type: input
+  id: object
+  attributes:
+    label: Object
+    description: The object of the commitment, i.e. the information or interaction whose handling will be constrained by the associated terms.
+    placeholder: personal data of business users
+- type: textarea
+  id: examples
+  attributes:
+    label: Examples
+    description: |
+      Examples of documents of this new terms type with the URL address from which the document can be accessed, the title of the document provided at this URL and the name of the service. For example:
+      `https://www.partners.skyscanner.net/privacy-policy - Corporate Business Contact Privacy Notice - Skyscanner`
+    placeholder: | 
+      URL - Title - Service name
+- type: textarea
+  id: references
+  attributes:
+    label: References
+    description: Related resources that may help to understand the purpose of this type, such as legal definitions, or the discussions that led to the choice of this name.
+    placeholder: "Open Terms Archive discussion: https://github.com/OpenTermsArchive/engine/discussions/923"

--- a/.github/DISCUSSION_TEMPLATE/new-type.yml
+++ b/.github/DISCUSSION_TEMPLATE/new-type.yml
@@ -41,7 +41,6 @@ body:
     label: Examples
     description: |
       Examples of documents that contain terms of the suggested type, in the form `URL - Title - Service name`, one per line. Provide the URL address at which the document can be accessed; the title of the document provided at this URL; and the name of the service.
-      e.g. `https://www.partners.skyscanner.net/privacy-policy - Corporate Business Contact Privacy Notice - Skyscanner`
     placeholder: | 
       https://www.partners.skyscanner.net/privacy-policy - Corporate Business Contact Privacy Notice - Skyscanner
   validations:
@@ -51,7 +50,7 @@ body:
   attributes:
     label: References
     description: | 
-      Related resources that may help to understand the purpose of this type, such as legal definitions, or the discussions that led to the choice of this name. e.g. `Digital Service Act: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R2065`
+      Related resources that may help to understand the purpose of this type, such as legal definitions, or the discussions that led to the choice of this name.
     placeholder: "Digital Service Act: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R2065"
 - type: textarea
   id: comments

--- a/.github/DISCUSSION_TEMPLATE/new-type.yml
+++ b/.github/DISCUSSION_TEMPLATE/new-type.yml
@@ -1,11 +1,11 @@
-title: "Add: "
+title: "Add <suggested new type name>"
 labels: ["New type"]
 body:
 - type: input
   id: name
   attributes:
     label: Type name
-    description: The name of the terms type you would like to add.
+    description: The name of the terms type to add, in Title Case.
     placeholder: Business Privacy Policy
   validations:
     required: true
@@ -13,14 +13,14 @@ body:
   id: alternative-type-names
   attributes:
     label: Alternative type names
-    description: Different names for the same terms type.
+    description: Known synonyms for the same terms type.
     placeholder: Business Users Privacy Policy, Commercial Privacy Policy
 - type: input
   id: writer
   attributes:
     label: Writer
-    description: The writer of the document, in most cases the service provider itself.
-    placeholder: intermediation service provider
+    description: The author of the document, in most cases the service provider itself.
+    placeholder: service provider
 - type: input
   id: audience
   attributes:
@@ -38,10 +38,10 @@ body:
   attributes:
     label: Examples
     description: |
-      Examples of documents of this new terms type with the URL address from which the document can be accessed, the title of the document provided at this URL and the name of the service. For example:
+      Examples of documents that contain terms of the suggested type, in the form `URL - Title - Service name`, one per line. Provide the URL address at which the document can be accessed; the title of the document provided at this URL; and the name of the service.
       `https://www.partners.skyscanner.net/privacy-policy - Corporate Business Contact Privacy Notice - Skyscanner`
     placeholder: | 
-      URL - Title - Service name
+https://www.partners.skyscanner.net/privacy-policy - Corporate Business Contact Privacy Notice - Skyscanner
 - type: textarea
   id: references
   attributes:

--- a/.github/DISCUSSION_TEMPLATE/new-type.yml
+++ b/.github/DISCUSSION_TEMPLATE/new-type.yml
@@ -14,7 +14,9 @@ body:
   attributes:
     label: Alternative type names
     description: Known synonyms for the same terms type.
-    placeholder: Business Users Privacy Policy, Commercial Privacy Policy
+    placeholder: | 
+      Business Users Privacy Policy
+      Commercial Privacy Policy
 - type: input
   id: writer
   attributes:
@@ -39,12 +41,20 @@ body:
     label: Examples
     description: |
       Examples of documents that contain terms of the suggested type, in the form `URL - Title - Service name`, one per line. Provide the URL address at which the document can be accessed; the title of the document provided at this URL; and the name of the service.
-      `https://www.partners.skyscanner.net/privacy-policy - Corporate Business Contact Privacy Notice - Skyscanner`
+      e.g. `https://www.partners.skyscanner.net/privacy-policy - Corporate Business Contact Privacy Notice - Skyscanner`
     placeholder: | 
-https://www.partners.skyscanner.net/privacy-policy - Corporate Business Contact Privacy Notice - Skyscanner
+      https://www.partners.skyscanner.net/privacy-policy - Corporate Business Contact Privacy Notice - Skyscanner
+  validations:
+    required: true
 - type: textarea
   id: references
   attributes:
     label: References
-    description: Related resources that may help to understand the purpose of this type, such as legal definitions, or the discussions that led to the choice of this name.
-    placeholder: "Open Terms Archive discussion: https://github.com/OpenTermsArchive/engine/discussions/923"
+    description: | 
+      Related resources that may help to understand the purpose of this type, such as legal definitions, or the discussions that led to the choice of this name. e.g. `Digital Service Act: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R2065`
+    placeholder: "Digital Service Act: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R2065"
+- type: textarea
+  id: comments
+  attributes:
+    label: Comments
+    description: Any additional information that may help to understand the purpose of this type.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format is based on [Common Changelog](https://common-changelog.org).\
 Unlike Common Changelog, the `unreleased` section of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) is preserved with the addition of a tag to specify which type of release should be published and to foster discussions about it inside pull requests. This tag should be one of the names mandated by SemVer, within brackets: `[patch]`, `[minor]` or `[major]`. For example: `## Unreleased [minor]`.
 
+## Unreleased [no-release]
+
+_Modifications made in this changeset do not add, remove or alter any behavior, dependency, API or functionality of the software. They only change non-functional parts of the repository, such as the README file or CI workflows._
+
 ## Unreleased
 
 ## 1.1.0 - 2023-10-25


### PR DESCRIPTION
Adds a template to create a discussion for adding new terms type. This can be tested on my fork [here](https://github.com/clementbiron/terms-types/discussions/new?category=new-type). I would have liked to be able to create a table (as we currently do by hand) from the examples provided but I haven't found an easy way to do it trough this template.

You can see an example of the result of the discussion opened with this template at this [address](https://github.com/clementbiron/terms-types/discussions/4).


