### PR TITLE
Improve new type discussion template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/suggestions.yml
+++ b/.github/DISCUSSION_TEMPLATE/suggestions.yml
@@ -40,9 +40,9 @@ body:
   attributes:
     label: Examples
     description: |
-      Examples of documents that contain terms of the suggested type, in the form `URL - Title - Service name`, one per line. Provide the URL address at which the document can be accessed; the title of the document provided at this URL; and the name of the service.
+      Examples of documents that contain terms of the suggested type, in the form `URL - Title - Jurisdiction`, one per line. Provide the URL address at which the document can be accessed; the title of the document provided at this URL; and, if possible, the jurisdiction to which the document refers.
     placeholder: | 
-      https://www.partners.skyscanner.net/privacy-policy - Corporate Business Contact Privacy Notice - Skyscanner
+      https://www.whatsapp.com/legal/privacy-policy-eea?lang=en - Privacy Policy - European Economic Area
   validations:
     required: true
 - type: textarea

--- a/.github/DISCUSSION_TEMPLATE/suggestions.yml
+++ b/.github/DISCUSSION_TEMPLATE/suggestions.yml
@@ -1,14 +1,6 @@
 title: "Add <suggested new type name>"
 labels: ["New type"]
 body:
-- type: input
-  id: name
-  attributes:
-    label: Type name
-    description: The name of the terms type to add, in Title Case.
-    placeholder: Business Privacy Policy
-  validations:
-    required: true
 - type: textarea
   id: alternative-type-names
   attributes:

--- a/.github/DISCUSSION_TEMPLATE/suggestions.yml
+++ b/.github/DISCUSSION_TEMPLATE/suggestions.yml
@@ -4,11 +4,11 @@ body:
 - type: markdown
   attributes:
     value: | 
-## Thank you for suggesting a new type!
+      ## Thank you for suggesting a new type!
 
-**Terms types** enable discovering terms and comparing them across services. Once a type is in use, it is there to stay. It is therefore critical to ensure that each type is well defined and has actual uses. The questions below will help define the type and enable the Open Terms Archive community to discuss its relevance to the wider ecosystem.
+      **Terms types** enable discovering terms and comparing them across services. Once a type is in use, it is there to stay. It is therefore critical to ensure that each type is well defined and has actual uses. The questions below will help define the type and enable the Open Terms Archive community to discuss its relevance to the wider ecosystem.
 
-Before suggesting a new type, please make sure to go through the ones that have already been suggested. If your suggestion has already been made somewhere else, even under a different name, please upvote it and join the existing discussion.
+      Before suggesting a new type, please make sure to go through the ones that have already been suggested. If your suggestion has already been made somewhere else, even under a different name, please upvote it and join the existing discussion.
 - type: textarea
   id: alternative-type-names
   attributes:

--- a/.github/DISCUSSION_TEMPLATE/suggestions.yml
+++ b/.github/DISCUSSION_TEMPLATE/suggestions.yml
@@ -10,12 +10,6 @@ body:
       Business Users Privacy Policy
       Commercial Privacy Policy
 - type: input
-  id: writer
-  attributes:
-    label: Writer
-    description: The author of the document, in most cases the service provider itself.
-    placeholder: service provider
-- type: input
   id: audience
   attributes:
     label: Audience

--- a/.github/DISCUSSION_TEMPLATE/suggestions.yml
+++ b/.github/DISCUSSION_TEMPLATE/suggestions.yml
@@ -1,4 +1,4 @@
-title: "Add <suggested new type name>"
+title: "<suggested new type name>"
 labels: ["New type"]
 body:
 - type: textarea

--- a/.github/DISCUSSION_TEMPLATE/suggestions.yml
+++ b/.github/DISCUSSION_TEMPLATE/suggestions.yml
@@ -8,7 +8,7 @@ body:
 
       **Terms types** enable discovering terms and comparing them across services. Once a type is in use, it is there to stay. It is therefore critical to ensure that each type is well defined and has actual uses. The questions below will help define the type and enable the Open Terms Archive community to discuss its relevance to the wider ecosystem.
 
-      Before suggesting a new type, please make sure to go through the ones that have already been suggested. If your suggestion has already been made somewhere else, even under a different name, please upvote it and join the existing discussion.
+      ### If no existing [implemented or suggested type](https://github.com/OpenTermsArchive/terms-types/discussions) matches your suggestion, fill in the fields below and start a discussion!
 - type: textarea
   id: examples
   attributes:

--- a/.github/DISCUSSION_TEMPLATE/suggestions.yml
+++ b/.github/DISCUSSION_TEMPLATE/suggestions.yml
@@ -4,31 +4,35 @@ body:
 - type: markdown
   attributes:
     value: | 
-      Please share the details below to help the community to better understand your terms type suggestion.
+## Thank you for suggesting a new type!
+
+**Terms types** enable discovering terms and comparing them across services. Once a type is in use, it is there to stay. It is therefore critical to ensure that each type is well defined and has actual uses. The questions below will help define the type and enable the Open Terms Archive community to discuss its relevance to the wider ecosystem.
+
+Before suggesting a new type, please make sure to go through the ones that have already been suggested. If your suggestion has already been made somewhere else, even under a different name, please upvote it and join the existing discussion.
 - type: textarea
   id: alternative-type-names
   attributes:
-    label: What are the alternative names for this type?
-    description: Known synonyms for the same terms type.
+    label: What are some alternative names for this type?
+    description: Known synonyms or other ideas you have for this same terms type.
     placeholder: | 
       Business Users Privacy Policy
       Commercial Privacy Policy
 - type: input
   id: audience
   attributes:
-    label: Who is the target audience for these terms?
-    description: The targeted audience whose rights and duties are defined in the associated terms.
+    label: Who is the target of these terms?
+    description: The entities whose rights and duties are defined in the associated terms.
     placeholder: business user
 - type: input
   id: object
   attributes:
     label: What is the object of commitment in these terms?
-    description: i.e. the information or interaction whose handling will be constrained by the associated terms.
+    description: The information handling or interaction that is constrained by the associated terms.
     placeholder: personal data of business users
 - type: textarea
   id: examples
   attributes:
-    label: Can you provide examples of documents containing these terms?
+    label: What are some documents containing these terms?
     description: |
       Examples of documents that contain terms of the suggested type, in the form `URL - Title - Jurisdiction`, one per line. Provide the URL address at which the document can be accessed; the title of the document provided at this URL; and, if possible, the jurisdiction to which the document refers.
     placeholder: | 
@@ -40,7 +44,7 @@ body:
   attributes:
     label: Are there any relevant references for this type?
     description: | 
-      Related references such as legal definitions, or the discussions that led to the choice of this name.
+      Related resources such as legal definitions, or the discussions that led to the choice of this name.
     placeholder: "Digital Service Act: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R2065"
 - type: textarea
   id: comments

--- a/.github/DISCUSSION_TEMPLATE/suggestions.yml
+++ b/.github/DISCUSSION_TEMPLATE/suggestions.yml
@@ -1,10 +1,14 @@
 title: "<suggested new type name>"
 labels: ["New type"]
 body:
+- type: markdown
+  attributes:
+    value: | 
+      Please share the details below to help the community to better understand your terms type suggestion.
 - type: textarea
   id: alternative-type-names
   attributes:
-    label: Alternative type names
+    label: What are the alternative names for this type?
     description: Known synonyms for the same terms type.
     placeholder: | 
       Business Users Privacy Policy
@@ -12,19 +16,19 @@ body:
 - type: input
   id: audience
   attributes:
-    label: Audience
+    label: Who is the target audience for these terms?
     description: The targeted audience whose rights and duties are defined in the associated terms.
     placeholder: business user
 - type: input
   id: object
   attributes:
-    label: Object
-    description: The object of the commitment, i.e. the information or interaction whose handling will be constrained by the associated terms.
+    label: What is the object of commitment in these terms?
+    description: i.e. the information or interaction whose handling will be constrained by the associated terms.
     placeholder: personal data of business users
 - type: textarea
   id: examples
   attributes:
-    label: Examples
+    label: Can you provide examples of documents containing these terms?
     description: |
       Examples of documents that contain terms of the suggested type, in the form `URL - Title - Jurisdiction`, one per line. Provide the URL address at which the document can be accessed; the title of the document provided at this URL; and, if possible, the jurisdiction to which the document refers.
     placeholder: | 
@@ -34,12 +38,12 @@ body:
 - type: textarea
   id: references
   attributes:
-    label: References
+    label: Are there any relevant references for this type?
     description: | 
-      Related resources that may help to understand the purpose of this type, such as legal definitions, or the discussions that led to the choice of this name.
+      Related references such as legal definitions, or the discussions that led to the choice of this name.
     placeholder: "Digital Service Act: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R2065"
 - type: textarea
   id: comments
   attributes:
-    label: Comments
-    description: Any additional information that may help to understand the purpose of this type.
+    label: Do you have any additional comments or information?
+    description: That may help to understand the purpose of this type.

--- a/.github/DISCUSSION_TEMPLATE/suggestions.yml
+++ b/.github/DISCUSSION_TEMPLATE/suggestions.yml
@@ -10,6 +10,16 @@ body:
 
       Before suggesting a new type, please make sure to go through the ones that have already been suggested. If your suggestion has already been made somewhere else, even under a different name, please upvote it and join the existing discussion.
 - type: textarea
+  id: examples
+  attributes:
+    label: What are some documents containing these terms?
+    description: |
+      Examples of documents that contain terms of the suggested type, in the form `Service name - URL - Document title - Jurisdiction`, one per line. Provide the URL address at which the document can be accessed; the title of the document provided at this URL; and, if possible, the jurisdiction to which the document refers.
+    placeholder: | 
+      WhatsApp - https://www.whatsapp.com/legal/privacy-policy-eea?lang=en - Privacy Policy - European Economic Area
+  validations:
+    required: true
+- type: textarea
   id: alternative-type-names
   attributes:
     label: What are some alternative names for this type?
@@ -29,16 +39,6 @@ body:
     label: What is the object of commitment in these terms?
     description: The information handling or interaction that is constrained by the associated terms.
     placeholder: personal data of business users
-- type: textarea
-  id: examples
-  attributes:
-    label: What are some documents containing these terms?
-    description: |
-      Examples of documents that contain terms of the suggested type, in the form `Service name - URL - Document title - Jurisdiction`, one per line. Provide the URL address at which the document can be accessed; the title of the document provided at this URL; and, if possible, the jurisdiction to which the document refers.
-    placeholder: | 
-      WhatsApp - https://www.whatsapp.com/legal/privacy-policy-eea?lang=en - Privacy Policy - European Economic Area
-  validations:
-    required: true
 - type: textarea
   id: references
   attributes:

--- a/.github/DISCUSSION_TEMPLATE/suggestions.yml
+++ b/.github/DISCUSSION_TEMPLATE/suggestions.yml
@@ -34,9 +34,9 @@ Before suggesting a new type, please make sure to go through the ones that have 
   attributes:
     label: What are some documents containing these terms?
     description: |
-      Examples of documents that contain terms of the suggested type, in the form `URL - Title - Jurisdiction`, one per line. Provide the URL address at which the document can be accessed; the title of the document provided at this URL; and, if possible, the jurisdiction to which the document refers.
+      Examples of documents that contain terms of the suggested type, in the form `Service name - URL - Document title - Jurisdiction`, one per line. Provide the URL address at which the document can be accessed; the title of the document provided at this URL; and, if possible, the jurisdiction to which the document refers.
     placeholder: | 
-      https://www.whatsapp.com/legal/privacy-policy-eea?lang=en - Privacy Policy - European Economic Area
+      WhatsApp - https://www.whatsapp.com/legal/privacy-policy-eea?lang=en - Privacy Policy - European Economic Area
   validations:
     required: true
 - type: textarea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All changes that impact users of this module are documented in this file, in the
 - Use [@OpenTermsArchive/changelog-action](https://github.com/OpenTermsArchive/changelog-action/) in CI/CD
 - Decrease package size to half
 
+## Unreleased [no-release]
+
+_Modifications made in this changeset do not add, remove or alter any behavior, dependency, API or functionality of the software. They only change non-functional parts of the repository, such as the README file or CI workflows._
+
 ## 1.1.0 - 2023-10-25
 
 ### Added


### PR DESCRIPTION
Improve the template to create a discussion for adding new terms type. This can be tested on my fork [here](https://github.com/clementbiron/terms-types/discussions/new?category=new-type).

You can see an example of the result of the discussion opened with this template at this [address](https://github.com/clementbiron/terms-types/discussions/10).


