### PR TITLE
Enable release workflow with branch protection

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,6 +2,8 @@ name: Changelog
 
 on:
   pull_request:
+  push:
+    branches: [ 'push-action/**' ]  # enable testing required checks, see https://github.com/CasperWA/push-protected?tab=readme-ov-file#update-your-workflow
   workflow_call:
     outputs:
       release-type:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   validate-changelog:
+    if: github.base_ref == 'main' || github.base_ref == 'test-main'  # check that changelog has valid unreleased changes only in PRs that could trigger a release
     runs-on: [ ubuntu-latest ]
     outputs:
       release-type: ${{ steps.validate-changelog.outputs.release-type }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release
 
 on:
-  push:
-    branches: [ main ]
+  pull_request_target:
+    branches: [ main, test-main ]
+    types: [ closed ]
 
 jobs:
   changelog:
@@ -12,6 +13,7 @@ jobs:
     uses: ./.github/workflows/test.yml
 
   release:
+    if: github.event.pull_request.merged == true
     needs: [ changelog, test ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
           branch: main
-          unprotect_reviews: true
           tags: true
           interval: 10  # seconds between checks
           pre_sleep: 15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,6 @@ jobs:
           git config user.name "Open Terms Archive Release Bot"
           git config user.email "release-bot@opentermsarchive.org"
           git commit --message="Update changelog" CHANGELOG.md package.json package-lock.json
-          git push origin
           git rev-parse v${{ steps.update-changelog.outputs.version }} || git tag v${{ steps.update-changelog.outputs.version }}
 
       - name: Run status checks for release commit on temporary branch # Use temporary branch to enable pushing commits to this branch protected by required status checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           git commit --message="Update changelog" CHANGELOG.md package.json package-lock.json
           [ ${{ needs.changelog.outputs.release-type }} != 'no-release' ] && git tag v${{ steps.update-changelog.outputs.version }}
 
-      - name: Run status checks for release commit on temporary branch # Use temporary branch to enable pushing commits to this branch protected by required status checks
+      - name: Run status checks for release commit on temporary branch  # use temporary branch to enable pushing commits to this branch protected by required status checks
         uses: CasperWA/push-protected@v2
         with:
           token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,7 @@ jobs:
           git config user.email "release-bot@opentermsarchive.org"
           git commit --message="Update changelog" CHANGELOG.md package.json package-lock.json
           git push origin
-
-      - name: Tag commit
-        if: needs.changelog.outputs.release-type != 'no-release'
-        run: |
-          git tag v${{ steps.update-changelog.outputs.version }}
-          git push origin --tags
+          git rev-parse v${{ steps.update-changelog.outputs.version }} || git tag v${{ steps.update-changelog.outputs.version }}
 
       - name: Run status checks for release commit on temporary branch # Use temporary branch to enable pushing commits to this branch protected by required status checks
         uses: CasperWA/push-protected@v2
@@ -44,6 +39,7 @@ jobs:
           token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
           branch: main
           unprotect_reviews: true
+          tags: true
 
       - name: Publish to NPM public repository
         if: needs.changelog.outputs.release-type != 'no-release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,10 @@ jobs:
           git config user.name "Open Terms Archive Release Bot"
           git config user.email "release-bot@opentermsarchive.org"
           git commit --message="Update changelog" CHANGELOG.md package.json package-lock.json
-          git rev-parse v${{ steps.update-changelog.outputs.version }} || git tag v${{ steps.update-changelog.outputs.version }}
+
+      - name: Tag commit
+        if: needs.changelog.outputs.release-type != 'no-release'
+        run: git tag v${{ steps.update-changelog.outputs.version }}
 
       - name: Run status checks for release commit on temporary branch # Use temporary branch to enable pushing commits to this branch protected by required status checks
         uses: CasperWA/push-protected@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ jobs:
           branch: main
           unprotect_reviews: true
           tags: true
+          interval: 10  # seconds between checks
+          pre_sleep: 15
+          fail_fast: true
 
       - name: Publish to NPM public repository
         if: needs.changelog.outputs.release-type != 'no-release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,13 @@ jobs:
           git tag v${{ steps.update-changelog.outputs.version }}
           git push origin --tags
 
+      - name: Run status checks for release commit on temporary branch # Use temporary branch to enable pushing commits to this branch protected by required status checks
+        uses: CasperWA/push-protected@v2
+        with:
+          token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          branch: main
+          unprotect_reviews: true
+
       - name: Publish to NPM public repository
         if: needs.changelog.outputs.release-type != 'no-release'
         uses: JS-DevTools/npm-publish@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
           branch: main
+          acceptable_conclusions: 'success,skipped'  # changelog checks are skipped when not in a PR towards main branch
           tags: true
           interval: 10  # seconds between checks
           pre_sleep: 15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,7 @@ jobs:
           git config user.name "Open Terms Archive Release Bot"
           git config user.email "release-bot@opentermsarchive.org"
           git commit --message="Update changelog" CHANGELOG.md package.json package-lock.json
-
-      - name: Tag commit
-        if: needs.changelog.outputs.release-type != 'no-release'
-        run: git tag v${{ steps.update-changelog.outputs.version }}
+          [ ${{ needs.changelog.outputs.release-type }} != 'no-release' ] && git tag v${{ steps.update-changelog.outputs.version }}
 
       - name: Run status checks for release commit on temporary branch # Use temporary branch to enable pushing commits to this branch protected by required status checks
         uses: CasperWA/push-protected@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Validate document types
 
 on:
   push:
-    branches-ignore: [ main ]  # will be called from workflow call
+    branches-ignore: [ main, test-main ]  # will be called from workflow call
   workflow_call:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,8 @@ name: Validate document types
 on:
   push:
     branches-ignore: [ main ]  # will be called from workflow call
-  pull_request:
-    types: [ opened, reopened ]
   workflow_call:
-  
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@ All changes that impact users of this module are documented in this file, in the
 - Use [@OpenTermsArchive/changelog-action](https://github.com/OpenTermsArchive/changelog-action/) in CI/CD
 - Decrease package size to half
 
-## Unreleased [no-release]
-
-_Modifications made in this changeset do not add, remove or alter any behavior, dependency, API or functionality of the software. They only change non-functional parts of the repository, such as the README file or CI workflows._
-
 ## 1.1.0 - 2023-10-25
 
 ### Added


### PR DESCRIPTION
The release workflow implemented in #47 did not take into account the necessary adaptations for `main` being a protected branch.
This changeset also eliminates duplicate test runs, and stop requiring @OTA-release-bot from being admin.

I decided to leave some `test-main` mentions in branch triggers, in order to ease future testing. In this way, creating a `test-main` branch enables testing deployment workflows without editing them. I would understand if this is not welcome and can remove it.