### PR TITLE
Update CI dependencies and job name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,10 @@ jobs:
           [ ${{ needs.changelog.outputs.release-type }} != 'no-release' ] && git tag v${{ steps.update-changelog.outputs.version }}
 
       - name: Run status checks for release commit on temporary branch  # use temporary branch to enable pushing commits to this branch protected by required status checks
-        uses: CasperWA/push-protected@v2
+        uses: CasperWA/push-protected@v2.16  # 2.16 minimum is required to benefit from updated defaults
         with:
           token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
           branch: main
-          acceptable_conclusions: 'success,skipped'  # changelog checks are skipped when not in a PR towards main branch
           tags: true
           interval: 10  # seconds between checks
           pre_sleep: 15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
 
 jobs:
-  validate:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All changes that impact users of this module are documented in this file, in the [Common Changelog](https://common-changelog.org) format with some additional specifications defined in the [CONTRIBUTING](./CONTRIBUTING.md) file. This codebase adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased [no-release]
+
+_Modifications made in this changeset do not add, remove or alter any behavior, dependency, API or functionality of the software. They only change non-functional parts of the repository, such as the README file or CI workflows._
+
 ## 1.2.0 - 2024-07-15
 
 _Full changeset and discussions: [#57](https://github.com/OpenTermsArchive/terms-types/pull/57)._


### PR DESCRIPTION
- Update push-protected GitHub action following https://github.com/CasperWA/push-protected/pull/250.
- Increase distinction between jobs names in UI, as `validate-changelog` and `validate` are too similar.