### PR TITLE
Add 6 terms types, `also known as` and legal references format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All changes that impact users of this module are documented in this file, in the
 - Add Editorial Policy ([discussions/35](https://github.com/OpenTermsArchive/terms-types/discussions/35))
 - Add Hyperlinks Policy ([discussions/43](https://github.com/OpenTermsArchive/terms-types/discussions/43))
 - Add Whistleblower Policy ([discussions/37](https://github.com/OpenTermsArchive/terms-types/discussions/37))
+- Add `also known as` property for synonyms
 - Add leading jurisdiction emoji for legal references
 
 ## 1.2.0 - 2024-07-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All changes that impact users of this module are documented in this file, in the [Common Changelog](https://common-changelog.org) format with some additional specifications defined in the [CONTRIBUTING](./CONTRIBUTING.md) file. This codebase adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased [minor]
+
+### Added
+
+- Add Editorial Policy ([discussions/35](https://github.com/OpenTermsArchive/terms-types/discussions/35))
+
 ## 1.2.0 - 2024-07-15
 
 _Full changeset and discussions: [#57](https://github.com/OpenTermsArchive/terms-types/pull/57)._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All changes that impact users of this module are documented in this file, in the
 - Add Accessibility Statement ([discussions/36](https://github.com/OpenTermsArchive/terms-types/discussions/36))
 - Add Editorial Policy ([discussions/35](https://github.com/OpenTermsArchive/terms-types/discussions/35))
 - Add Anti-corruption Policy ([discussions/39](https://github.com/OpenTermsArchive/terms-types/discussions/39))
+- Add Hyperlinks Policy ([discussions/43](https://github.com/OpenTermsArchive/terms-types/discussions/43))
 - Add leading jurisdiction emoji for legal references
 
 ## 1.2.0 - 2024-07-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All changes that impact users of this module are documented in this file, in the
 - Add `Whistleblower Policy` ([discussions/37](https://github.com/OpenTermsArchive/terms-types/discussions/37))
 - Add `also known as` property for synonyms
 - Add leading jurisdiction emoji for legal references
+- Add `also known as` data
 
 ## 1.2.0 - 2024-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All changes that impact users of this module are documented in this file, in the
 
 ### Added
 
+- Add Accessibility Statement ([discussions/36](https://github.com/OpenTermsArchive/terms-types/discussions/36))
 - Add Editorial Policy ([discussions/35](https://github.com/OpenTermsArchive/terms-types/discussions/35))
 - Add Anti-corruption Policy ([discussions/39](https://github.com/OpenTermsArchive/terms-types/discussions/39))
 - Add leading jurisdiction emoji for legal references

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,16 @@ All changes that impact users of this module are documented in this file, in the
 
 ## Unreleased [minor]
 
+> Development of this release was supported by the [NGI0 Entrust Fund](https://nlnet.nl/entrust), a fund established by [NLnet](https://nlnet.nl/) with financial support from the European Commission's [Next Generation Internet](https://www.ngi.eu) programme, under the aegis of DG CNECT under grant agreement N°101069594. [Learn more](https://nlnet.nl/project/TOSDR-OTA/) on the NLNet website.
+
 ### Added
 
-- Add Accessibility Statement ([discussions/36](https://github.com/OpenTermsArchive/terms-types/discussions/36))
-- Add Affiliate Agreement ([discussions/41](https://github.com/OpenTermsArchive/terms-types/discussions/41))
-- Add Anti-corruption Policy ([discussions/39](https://github.com/OpenTermsArchive/terms-types/discussions/39))
-- Add Editorial Policy ([discussions/35](https://github.com/OpenTermsArchive/terms-types/discussions/35))
-- Add Hyperlinks Policy ([discussions/43](https://github.com/OpenTermsArchive/terms-types/discussions/43))
-- Add Whistleblower Policy ([discussions/37](https://github.com/OpenTermsArchive/terms-types/discussions/37))
+- Add `Accessibility Statement` ([discussions/36](https://github.com/OpenTermsArchive/terms-types/discussions/36))
+- Add `Affiliate Agreement` ([discussions/41](https://github.com/OpenTermsArchive/terms-types/discussions/41))
+- Add `Anti-corruption Policy` ([discussions/39](https://github.com/OpenTermsArchive/terms-types/discussions/39))
+- Add `Editorial Policy` ([discussions/35](https://github.com/OpenTermsArchive/terms-types/discussions/35))
+- Add `Hyperlinks Policy` ([discussions/43](https://github.com/OpenTermsArchive/terms-types/discussions/43))
+- Add `Whistleblower Policy` ([discussions/37](https://github.com/OpenTermsArchive/terms-types/discussions/37))
 - Add `also known as` property for synonyms
 - Add leading jurisdiction emoji for legal references
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All changes that impact users of this module are documented in this file, in the
 - Add Editorial Policy ([discussions/35](https://github.com/OpenTermsArchive/terms-types/discussions/35))
 - Add Anti-corruption Policy ([discussions/39](https://github.com/OpenTermsArchive/terms-types/discussions/39))
 - Add Hyperlinks Policy ([discussions/43](https://github.com/OpenTermsArchive/terms-types/discussions/43))
+- Add Whistleblower Policy ([discussions/37](https://github.com/OpenTermsArchive/terms-types/discussions/37))
 - Add leading jurisdiction emoji for legal references
 
 ## 1.2.0 - 2024-07-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All changes that impact users of this module are documented in this file, in the
 
 - Add Editorial Policy ([discussions/35](https://github.com/OpenTermsArchive/terms-types/discussions/35))
 - Add Anti-corruption Policy ([discussions/39](https://github.com/OpenTermsArchive/terms-types/discussions/39))
+- Add leading jurisdiction emoji for legal references
 
 ## 1.2.0 - 2024-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All changes that impact users of this module are documented in this file, in the
 ### Added
 
 - Add Editorial Policy ([discussions/35](https://github.com/OpenTermsArchive/terms-types/discussions/35))
+- Add Anti-corruption Policy ([discussions/39](https://github.com/OpenTermsArchive/terms-types/discussions/39))
 
 ## 1.2.0 - 2024-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All changes that impact users of this module are documented in this file, in the
 - Add `Whistleblower Policy` ([discussions/37](https://github.com/OpenTermsArchive/terms-types/discussions/37))
 - Add `also known as` property for synonyms
 - Add leading jurisdiction emoji for legal references
-- Add `also known as` data
+- Add legal references and `also known as` data
 
 ## 1.2.0 - 2024-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ All changes that impact users of this module are documented in this file, in the
 ### Added
 
 - Add Accessibility Statement ([discussions/36](https://github.com/OpenTermsArchive/terms-types/discussions/36))
-- Add Editorial Policy ([discussions/35](https://github.com/OpenTermsArchive/terms-types/discussions/35))
+- Add Affiliate Agreement ([discussions/41](https://github.com/OpenTermsArchive/terms-types/discussions/41))
 - Add Anti-corruption Policy ([discussions/39](https://github.com/OpenTermsArchive/terms-types/discussions/39))
+- Add Editorial Policy ([discussions/35](https://github.com/OpenTermsArchive/terms-types/discussions/35))
 - Add Hyperlinks Policy ([discussions/43](https://github.com/OpenTermsArchive/terms-types/discussions/43))
 - Add Whistleblower Policy ([discussions/37](https://github.com/OpenTermsArchive/terms-types/discussions/37))
 - Add leading jurisdiction emoji for legal references

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,10 @@ Ensure that this name (or any close one) is not already used in the [database](.
 
 Note that service-specific types (such as “Twitter Privacy Policy”) are not allowed. Terms types aim at allowing comparisons across services and should thus be generic.
 
+#### Use singular
+
+For consistency, the term “Policy” in a type name should only be used singular (“policy”), never plural (“policies”). Similarly, all terms types should have a singular name.
+
 #### Alternative names
 
 Some terms types might have several commonly-used names, often varying by jurisdiction. To increase discoverability and clarity, alternative names can be provided to terms types. These alternative names are not translations, but rather synonyms in English. They are provided in an array under the `also known as` key.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,19 +30,6 @@ Ensure that this name (or any close one) is not already used in the [database](.
 
 Note that service-specific types (such as “Twitter Privacy Policy”) are not allowed. Terms types aim at allowing comparisons across services and should thus be generic.
 
-#### Use singular
-
-For consistency, the term “Policy” in a type name should only be used singular (“policy”), never plural (“policies”). Similarly, all terms types should have a singular name.
-
-#### Alternative names
-
-Some terms types might have several commonly-used names, often varying by jurisdiction. To increase discoverability and clarity, alternative names can be provided to terms types. These alternative names are not translations, but rather synonyms in English. They are provided in an array under the `also known as` key.
-
-Examples:
-
-- `"Hyperlinks Policy" : { "also known as": [ "Links Policy", "Linking Policy" ], … }`
-- `"Whistleblower Policy": { "also known as": [ "Whistleblower Protections" ], … }`
-
 ### Provide examples
 
 Provide at least the terms you intend to track as example of the new terms type, with relevant information on its source and context:
@@ -56,15 +43,6 @@ Provide at least the terms you intend to track as example of the new terms type,
 Include any relevant [references](./README.md#references) that may help in understanding the purpose of this type. This could include legal definitions, discussions, or any other resource that provides context or background information.
 
 References will then be listed in the type definition, with their URL and a title describing the content and source.
-
-#### Legal references
-
-Legal references will be prefixed by the flag emoji of the jurisdiction of enactment, will use the full name of the law, and will link to the official journal URL.
-
-Examples:
-
-- `"🇬🇧 Bribery Act 2010": "https://www.legislation.gov.uk/ukpga/2010/23/contents"`
-- `"🇫🇷 Loi n°2005-102 du 11 février 2005 pour l'égalité des droits et des chances, la participation et la citoyenneté des personnes handicapées, article 47": "https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000001290363"`
 
 ### Build consensus
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,17 @@ Provide at least the terms you intend to track as example of the new terms type,
 
 Include any relevant [references](./README.md#references) that may help in understanding the purpose of this type. This could include legal definitions, discussions, or any other resource that provides context or background information.
 
+References will then be listed in the type definition, with their URL and a title describing the content and source.
+
+#### Legal references
+
+Legal references will be prefixed by the flag emoji of the jurisdiction of enactment, will use the full name of the law, and will link to the official journal URL.
+
+Examples:
+
+- `"🇬🇧 Bribery Act 2010": "https://www.legislation.gov.uk/ukpga/2010/23/contents"`
+- `"🇫🇷 Loi n°2005-102 du 11 février 2005 pour l'égalité des droits et des chances, la participation et la citoyenneté des personnes handicapées, article 47": "https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000001290363"`
+
 ### Build consensus
 
 Publicise your suggestion across Open Terms Archive channels and engage the community. Throughout the discussion, the name and the tryptich should be challenged, taking into account international perspectives on phrasings and the variety of definitions across jurisdictions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,15 @@ Ensure that this name (or any close one) is not already used in the [database](.
 
 Note that service-specific types (such as “Twitter Privacy Policy”) are not allowed. Terms types aim at allowing comparisons across services and should thus be generic.
 
+#### Alternative names
+
+Some terms types might have several commonly-used names, often varying by jurisdiction. To increase discoverability and clarity, alternative names can be provided to terms types. These alternative names are not translations, but rather synonyms in English. They are provided in an array under the `also known as` key.
+
+Examples:
+
+- `"Hyperlinks Policy" : { "also known as": [ "Links Policy", "Linking Policy" ], … }`
+- `"Whistleblower Policy": { "also known as": [ "Whistleblower Protections" ], … }`
+
 ### Provide examples
 
 Provide at least the terms you intend to track as example of the new terms type, with relevant information on its source and context:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ Once:
 - a consensus has been reached on the name;
 - at least 2 weeks have elapsed since the opening of the discussion, to ensure visibility throughout the community.
 
-Then the Open Terms Archive Core Team will review and validate the suggestion, considering factors like uniqueness, clarity, and relevance. If validated, the discussion will be turned into a pull request for addition into the database.
+Then the Open Terms Archive Core Team will review and validate the suggestion, considering factors like uniqueness, clarity, and relevance. If validated, the discussion will be turned into a pull request for addition into the database. To ease tracking and participation, each pull request will contain only one type addition, and will link to the discussion.
 
 ## Governance considerations
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ The name of each type is written with title capitalisation (every noun is capita
 
 It should be the most commonly used and most internationally understandable for this type.
 
+#### Use singular
+
+For consistency, the term “Policy” in a type name should only be used singular (“policy”), never plural (“policies”). Similarly, all terms types should have a singular name.
+
+### Alternative names
+
+Some terms types might have several commonly-used names, often varying by jurisdiction. To increase discoverability and clarity, alternative names can be provided to terms types. These alternative names are not translations, but rather synonyms in English. They are provided in an array under the `also known as` key.
+
+Examples:
+
+- `"Hyperlinks Policy" : { "also known as": [ "Links Policy", "Linking Policy" ], … }`
+- `"Whistleblower Policy": { "also known as": [ "Whistleblower Protections" ], … }`
+
 ### Tryptich
 
 In order to guide usage and disambiguate synonyms, each terms type is characterised by a tryptich along the three dimensions of the `commitment` that is being taken in it:
@@ -71,21 +84,32 @@ It may also contain an optional `references` property which contains a map of re
 }
 ```
 
+#### Legal references
+
+Legal references will be prefixed by the flag emoji of the jurisdiction of enactment, will use the full name of the law, and will link to the official journal URL.
+
+Examples:
+
+- `"🇬🇧 Bribery Act 2010": "https://www.legislation.gov.uk/ukpga/2010/23/contents"`
+- `"🇫🇷 Loi n°2005-102 du 11 février 2005 pour l'égalité des droits et des chances, la participation et la citoyenneté des personnes handicapées, article 47": "https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000001290363"`
+
 ### Example
 
 ```json
-{
-  "Business Mediation Policy": {
-    "commitment": {
-      "writer": "intermediation service provider",
-      "audience": "business users",
-      "object": "mediation process after internal complaints handling failed"
-    },
-    "references": {
-      "Open Terms Archive discussion": "https://github.com/OpenTermsArchive/engine/discussions/933",
-      "P2B Regulation 2019/1150, Article 12": "https://eur-lex.europa.eu/eli/reg/2019/1150/oj#d1e1148-57-1"
-    }
+"Whistleblower Policy": {
+  "also known as": [
+    "Whistleblower Protections"
+  ],
+  "commitment": {
+    "writer": "service provider",
+    "audience": "employees",
+    "object": "reporting on suspected misconduct and illegal acts and prevention of retaliation"
   },
+  "references": {
+    "Open Terms Archive discussion": "https://github.com/OpenTermsArchive/terms-types/discussions/37",
+    "🇺🇸 Whistleblower Protection Act of 1989": "https://www.govinfo.gov/content/pkg/STATUTE-103/pdf/STATUTE-103-Pg16.pdf",
+    "🇫🇷 Loi n°2016-1691 du 9 décembre 2016 relative à la transparence, à la lutte contre la corruption et à la modernisation de la vie économique, dite « Sapin II »": "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000033558528"
+  }
 }
 ```
 

--- a/termsTypes.json
+++ b/termsTypes.json
@@ -323,5 +323,16 @@
       "🇫🇷 Loi n°2016-1691 du 9 décembre 2016 relative à la transparence, à la lutte contre la corruption et à la modernisation de la vie économique, dite « Sapin II »": "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000033558528",
       "🇪🇺 Directive 2019/1937 of the European Parliament and of the Council of 23 October 2019 on the protection of persons who report breaches of Union law": "https://eur-lex.europa.eu/legal-content/en/TXT/?uri=CELEX%3A32019L1937"
     }
+  },
+  "Affiliate Agreement": {
+    "commitment": {
+      "writer": "service provider",
+      "audience": "affiliate",
+      "object": "earning commissions by promoting the service"
+    },
+    "references": {
+      "Open Terms Archive discussion": "https://github.com/OpenTermsArchive/terms-types/discussions/41",
+      "Wikipedia page on Affiliate Marketing": "https://en.wikipedia.org/wiki/Affiliate_marketing"
+    }
   }
 }

--- a/termsTypes.json
+++ b/termsTypes.json
@@ -1,5 +1,9 @@
 {
   "Terms of Service": {
+    "also known as": [
+      "Terms and Conditions",
+      "Terms of Use"
+    ],
     "commitment": {
       "writer": "service provider",
       "audience": "end user",
@@ -14,6 +18,9 @@
     }
   },
   "Imprint": {
+    "also known as": [
+      "Legal Notice"
+    ],
     "commitment": {
       "writer": "service provider",
       "audience": "everyone",
@@ -21,6 +28,9 @@
     }
   },
   "Trackers Policy": {
+    "also known as": [
+      "Cookies Policy"
+    ],
     "commitment": {
       "writer": "service provider",
       "audience": "end user",
@@ -28,6 +38,10 @@
     }
   },
   "Developer Terms": {
+    "also known as": [
+      "Developer Policy",
+      "Developer Agreement"
+    ],
     "commitment": {
       "writer": "service provider",
       "audience": "developer",
@@ -35,6 +49,9 @@
     }
   },
   "Community Guidelines": {
+    "also known as": [
+      "Community Standards"
+    ],
     "commitment": {
       "writer": "service provider",
       "audience": "end user",
@@ -49,6 +66,10 @@
     }
   },
   "Acceptable Use Policy": {
+    "also known as": [
+      "Fair Use Policy",
+      "Acceptable Usage Policy"
+    ],
     "commitment": {
       "writer": "service provider",
       "audience": "end user",
@@ -56,6 +77,10 @@
     }
   },
   "Restricted Use Policy": {
+    "also known as": [
+      "Limited Use Policy",
+      "Restriction Policy"
+    ],
     "commitment": {
       "writer": "service provider",
       "audience": "end user",
@@ -70,6 +95,10 @@
     }
   },
   "Copyright Claims Policy": {
+    "also known as": [
+      "Copyright Infringement Policy",
+      "Intellectual Property Policy"
+    ],
     "commitment": {
       "writer": "service provider",
       "audience": "copyrighted works rights holders",
@@ -77,6 +106,9 @@
     }
   },
   "Law Enforcement Guidelines": {
+    "also known as": [
+      "Legal Process Guidelines"
+    ],
     "commitment": {
       "writer": "service provider",
       "audience": "law enforcement authorities",
@@ -105,6 +137,10 @@
     }
   },
   "Brand Guidelines": {
+    "also known as": [
+      "Branding Policies",
+      "Trademark Usage Guidelines"
+    ],
     "commitment": {
       "writer": "service provider",
       "audience": "developer",
@@ -112,6 +148,9 @@
     }
   },
   "Quality Guidelines": {
+    "also known as": [
+      "Quality standards"
+    ],
     "commitment": {
       "writer": "service provider",
       "audience": "end user",
@@ -126,6 +165,9 @@
     }
   },
   "Data Processor Agreement": {
+    "also known as": [
+      "Data Processing Agreement"
+    ],
     "commitment": {
       "writer": "service provider",
       "audience": "data controllers (in the sense of GDPR)",
@@ -140,6 +182,11 @@
     }
   },
   "Closed Captioning Policy": {
+    "also known as": [
+      "Closed Captioning Guidelines",
+      "Captioning Policy",
+      "Closed Captioning Standards"
+    ],
     "commitment": {
       "writer": "service provider",
       "audience": "end user",
@@ -161,6 +208,9 @@
     }
   },
   "Vulnerability Disclosure Policy": {
+    "also known as": [
+      "Security Disclosure Policy"
+    ],
     "commitment": {
       "writer": "service provider",
       "audience": "vulnerability reporter",
@@ -182,6 +232,9 @@
     }
   },
   "Conditions of Carriage": {
+    "also known as": [
+      "Transport Conditions"
+    ],
     "commitment": {
       "writer": "transportation operator (airline, railway, bus…)",
       "audience": "passenger",
@@ -203,6 +256,9 @@
     }
   },
   "Marketplace Sellers Conditions": {
+    "also known as": [
+      "Seller Agreement"
+    ],
     "commitment": {
       "writer": "online marketplace",
       "audience": "seller",
@@ -223,6 +279,9 @@
     }
   },
   "Premium Partner Conditions": {
+    "also known as": [
+      "Premium Partner Program"
+    ],
     "commitment": {
       "writer": "intermediation service provider",
       "audience": "sellers of goods or services",

--- a/termsTypes.json
+++ b/termsTypes.json
@@ -263,5 +263,15 @@
     "references": {
       "Open Terms Archive discussion": "https://github.com/OpenTermsArchive/engine/discussions/923"
     }
+  },
+  "Editorial Policy": {
+    "commitment": {
+      "writer": "service provider",
+      "audience": "end user",
+      "object": "writing and publishing standards and principles"
+    },
+    "references": {
+      "Open Terms Archive discussion": "https://github.com/OpenTermsArchive/terms-types/discussions/35"
+    }
   }
 }

--- a/termsTypes.json
+++ b/termsTypes.json
@@ -300,5 +300,15 @@
       "🇬🇧 Public Sector Bodies Accessibility Regulations 2018/2022": "https://www.legislation.gov.uk/uksi/2018/952/made",
       "🇱🇺 Loi du 28 mai 2019 relative à l’accessibilité des sites internet et des applications mobiles des organismes du secteur public": "https://legilux.public.lu/eli/etat/leg/loi/2019/05/28/a373/jo"
     }
+  },
+  "Hyperlinks Policy": {
+    "commitment": {
+      "writer": "service provider",
+      "audience": "for outgoing hyperlinks, readers and contributors; for incoming hyperlinks, third-party authors who link to the service content",
+      "object": "quality of third-party targets of outgoing hyperlinks provided in content, and requirements for incoming hyperlinks in third-party content"
+    },
+    "references": {
+      "Open Terms Archive discussion": "https://github.com/OpenTermsArchive/terms-types/discussions/43"
+    }
   }
 }

--- a/termsTypes.json
+++ b/termsTypes.json
@@ -273,5 +273,19 @@
     "references": {
       "Open Terms Archive discussion": "https://github.com/OpenTermsArchive/terms-types/discussions/35"
     }
+  },
+  "Anti-corruption Policy": {
+    "commitment": {
+      "writer": "service provider",
+      "audience": "any person working directly or indirectly for the service provider",
+      "object": "risk mitigation and prevention of involvement in bribery"
+    },
+    "references": {
+      "Open Terms Archive discussion": "https://github.com/OpenTermsArchive/terms-types/discussions/39",
+      "USA Foreign Corrupt Practices Act": "https://www.justice.gov/criminal/criminal-fraud/foreign-corrupt-practices-act",
+      "UK Bribery Act 2010": "https://www.legislation.gov.uk/ukpga/2010/23/contents",
+      "ISO 37001 Anti-bribery management systems": "https://www.iso.org/iso-37001-anti-bribery-management.html",
+      "Loi n°2016-1691 du 9 décembre 2016 relative à la transparence, à la lutte contre la corruption et à la modernisation de la vie économique, dite « Sapin II »": "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000033558528"
+    }
   }
 }

--- a/termsTypes.json
+++ b/termsTypes.json
@@ -177,7 +177,7 @@
     ],
     "commitment": {
       "writer": "service provider",
-      "audience": "data controllers (in the sense of GDPR)",
+      "audience": "data processors (in the sense of GDPR)",
       "object": "status of data processor (in the sense of GDPR) for the service provider"
     },
     "references": {

--- a/termsTypes.json
+++ b/termsTypes.json
@@ -102,7 +102,10 @@
     "commitment": {
       "writer": "service provider",
       "audience": "copyrighted works rights holders",
-      "object": "how copyright complaints (DMCA…) will be handled"
+      "object": "how copyright complaints will be handled"
+    },
+    "references": {
+      "🇺🇸 Digital Millennium Copyright Act (DMCA)": "https://www.congress.gov/bill/105th-congress/house-bill/2281"
     }
   },
   "Law Enforcement Guidelines": {
@@ -162,6 +165,10 @@
       "writer": "service provider",
       "audience": "data controllers (in the sense of GDPR)",
       "object": "end user personal data"
+    },
+    "references": {
+      "🇪🇺 GDPR, article 4§7": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv:OJ.L_.2016.119.01.0001.01.ENG&toc=OJ:L:2016:119:FULL#d1e1489-1-1",
+      "European Commission guidance": "https://commission.europa.eu/law/law-topic/data-protection/reform/rules-business-and-organisations/obligations/controllerprocessor/what-data-controller-or-data-processor_en"
     }
   },
   "Data Processor Agreement": {
@@ -172,6 +179,10 @@
       "writer": "service provider",
       "audience": "data controllers (in the sense of GDPR)",
       "object": "status of data processor (in the sense of GDPR) for the service provider"
+    },
+    "references": {
+      "🇪🇺 GDPR, article 4§8": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv:OJ.L_.2016.119.01.0001.01.ENG&toc=OJ:L:2016:119:FULL#d1e1489-1-1",
+      "European Commission guidance": "https://commission.europa.eu/law/law-topic/data-protection/reform/rules-business-and-organisations/obligations/controllerprocessor/what-data-controller-or-data-processor_en"
     }
   },
   "User Consent Policy": {

--- a/termsTypes.json
+++ b/termsTypes.json
@@ -287,5 +287,18 @@
       "🇫🇷 Loi n°2016-1691 du 9 décembre 2016 relative à la transparence, à la lutte contre la corruption et à la modernisation de la vie économique, dite « Sapin II »": "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000033558528",
       "ISO 37001 Anti-bribery management systems": "https://www.iso.org/iso-37001-anti-bribery-management.html"
     }
+  },
+  "Accessibility Statement": {
+    "commitment": {
+      "writer": "service provider",
+      "audience": "everyone",
+      "object": "accessibility of the service to people with a disability"
+    },
+    "references": {
+      "Open Terms Archive discussion": "https://github.com/OpenTermsArchive/terms-types/discussions/36",
+      "🇫🇷 Loi n°2005-102 du 11 février 2005 pour l'égalité des droits et des chances, la participation et la citoyenneté des personnes handicapées, article 47": "https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000001290363",
+      "🇬🇧 Public Sector Bodies Accessibility Regulations 2018/2022": "https://www.legislation.gov.uk/uksi/2018/952/made",
+      "🇱🇺 Loi du 28 mai 2019 relative à l’accessibilité des sites internet et des applications mobiles des organismes du secteur public": "https://legilux.public.lu/eli/etat/leg/loi/2019/05/28/a373/jo"
+    }
   }
 }

--- a/termsTypes.json
+++ b/termsTypes.json
@@ -217,9 +217,9 @@
     },
     "references": {
       "Open Terms Archive Discussion": "https://github.com/OpenTermsArchive/engine/discussions/902",
-      "Article 5 of P2B Regulation 2019/1150": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=celex%3A32019R1150#d1e868-57-1",
-      "Article 6a of Directive 2011/83/EU": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02011L0083-20220528#tocId12",
-      "Point (m) of Article 2(1) of Directive 2005/29/EC": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:02005L0029-20220528#tocId5"
+      "🇪🇺 Article 5 of P2B Regulation 2019/1150": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=celex%3A32019R1150#d1e868-57-1",
+      "🇪🇺 Article 6a of Directive 2011/83/EU": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02011L0083-20220528#tocId12",
+      "🇪🇺 Point (m) of Article 2(1) of Directive 2005/29/EC": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:02005L0029-20220528#tocId5"
     }
   },
   "Premium Partner Conditions": {
@@ -240,7 +240,7 @@
     },
     "references": {
       "Open Terms Archive Discussion": "https://github.com/OpenTermsArchive/engine/discussions/940",
-      "P2B Regulation 2019/1150": "https://eur-lex.europa.eu/eli/reg/2019/1150/oj"
+      "🇪🇺 P2B Regulation 2019/1150": "https://eur-lex.europa.eu/eli/reg/2019/1150/oj"
     }
   },
   "Business Mediation Policy": {
@@ -251,7 +251,7 @@
     },
     "references": {
       "Open Terms Archive discussion": "https://github.com/OpenTermsArchive/engine/discussions/933",
-      "P2B Regulation 2019/1150, Article 12": "https://eur-lex.europa.eu/eli/reg/2019/1150/oj#d1e1148-57-1"
+      "🇪🇺 P2B Regulation 2019/1150, Article 12": "https://eur-lex.europa.eu/eli/reg/2019/1150/oj#d1e1148-57-1"
     }
   },
   "Business Privacy Policy": {
@@ -282,10 +282,10 @@
     },
     "references": {
       "Open Terms Archive discussion": "https://github.com/OpenTermsArchive/terms-types/discussions/39",
-      "USA Foreign Corrupt Practices Act": "https://www.justice.gov/criminal/criminal-fraud/foreign-corrupt-practices-act",
-      "UK Bribery Act 2010": "https://www.legislation.gov.uk/ukpga/2010/23/contents",
-      "ISO 37001 Anti-bribery management systems": "https://www.iso.org/iso-37001-anti-bribery-management.html",
-      "Loi n°2016-1691 du 9 décembre 2016 relative à la transparence, à la lutte contre la corruption et à la modernisation de la vie économique, dite « Sapin II »": "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000033558528"
+      "🇺🇸 Foreign Corrupt Practices Act": "https://www.justice.gov/criminal/criminal-fraud/foreign-corrupt-practices-act",
+      "🇬🇧 Bribery Act 2010": "https://www.legislation.gov.uk/ukpga/2010/23/contents",
+      "🇫🇷 Loi n°2016-1691 du 9 décembre 2016 relative à la transparence, à la lutte contre la corruption et à la modernisation de la vie économique, dite « Sapin II »": "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000033558528",
+      "ISO 37001 Anti-bribery management systems": "https://www.iso.org/iso-37001-anti-bribery-management.html"
     }
   }
 }

--- a/termsTypes.json
+++ b/termsTypes.json
@@ -310,5 +310,18 @@
     "references": {
       "Open Terms Archive discussion": "https://github.com/OpenTermsArchive/terms-types/discussions/43"
     }
+  },
+  "Whistleblower Policy": {
+    "commitment": {
+      "writer": "service provider",
+      "audience": "employees",
+      "object": "reporting on suspected misconduct and illegal acts and prevention of retaliation"
+    },
+    "references": {
+      "Open Terms Archive discussion": "https://github.com/OpenTermsArchive/terms-types/discussions/37",
+      "🇺🇸 Whistleblower Protection Act of 1989": "https://www.govinfo.gov/content/pkg/STATUTE-103/pdf/STATUTE-103-Pg16.pdf",
+      "🇫🇷 Loi n°2016-1691 du 9 décembre 2016 relative à la transparence, à la lutte contre la corruption et à la modernisation de la vie économique, dite « Sapin II »": "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000033558528",
+      "🇪🇺 Directive 2019/1937 of the European Parliament and of the Council of 23 October 2019 on the protection of persons who report breaches of Union law": "https://eur-lex.europa.eu/legal-content/en/TXT/?uri=CELEX%3A32019L1937"
+    }
   }
 }

--- a/termsTypes.json
+++ b/termsTypes.json
@@ -265,6 +265,9 @@
     }
   },
   "Editorial Policy": {
+    "also known as": [
+      "Editorial Guidelines"
+    ],
     "commitment": {
       "writer": "service provider",
       "audience": "end user",
@@ -275,6 +278,9 @@
     }
   },
   "Anti-corruption Policy": {
+    "also known as": [
+      "Anti-bribery Policy"
+    ],
     "commitment": {
       "writer": "service provider",
       "audience": "any person working directly or indirectly for the service provider",
@@ -289,6 +295,9 @@
     }
   },
   "Accessibility Statement": {
+    "also known as": [
+      "Accessibility Policy"
+    ],
     "commitment": {
       "writer": "service provider",
       "audience": "everyone",
@@ -307,11 +316,20 @@
       "audience": "for outgoing hyperlinks, readers and contributors; for incoming hyperlinks, third-party authors who link to the service content",
       "object": "quality of third-party targets of outgoing hyperlinks provided in content, and requirements for incoming hyperlinks in third-party content"
     },
+    "also known as": [
+      "Links Policy",
+      "Linking Policy",
+      "External Links Policy",
+      "Outgoing Links Policy"
+    ],
     "references": {
       "Open Terms Archive discussion": "https://github.com/OpenTermsArchive/terms-types/discussions/43"
     }
   },
   "Whistleblower Policy": {
+    "also known as": [
+      "Whistleblower Protections"
+    ],
     "commitment": {
       "writer": "service provider",
       "audience": "employees",
@@ -325,6 +343,9 @@
     }
   },
   "Affiliate Agreement": {
+    "also known as": [
+      "Affiliate Policy"
+    ],
     "commitment": {
       "writer": "service provider",
       "audience": "affiliate",

--- a/test/termsTypes.schema.js
+++ b/test/termsTypes.schema.js
@@ -7,6 +7,13 @@ const schema = {
       additionalProperties: false,
       required: ['commitment'],
       properties: {
+        'also known as': {
+          type: 'array',
+          items: {
+            type: 'string'
+          },
+          minItems: 1
+        },
         commitment: {
           type: 'object',
           additionalProperties: false,


### PR DESCRIPTION
- Add `Accessibility Statement` ([discussions/36](https://github.com/OpenTermsArchive/terms-types/discussions/36))
- Add `Affiliate Agreement` ([discussions/41](https://github.com/OpenTermsArchive/terms-types/discussions/41))
- Add `Anti-corruption Policy` ([discussions/39](https://github.com/OpenTermsArchive/terms-types/discussions/39))
- Add `Editorial Policy` ([discussions/35](https://github.com/OpenTermsArchive/terms-types/discussions/35))
- Add `Hyperlinks Policy` ([discussions/43](https://github.com/OpenTermsArchive/terms-types/discussions/43))
- Add `Whistleblower Policy` ([discussions/37](https://github.com/OpenTermsArchive/terms-types/discussions/37))
- Add `also known as` property for synonyms
- Add leading jurisdiction emoji for legal references