### PR TITLE
Support no-release release type

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,17 +32,21 @@ jobs:
           git config user.name "Open Terms Archive Release Bot"
           git config user.email "release-bot@opentermsarchive.org"
           git commit --message="Update changelog" CHANGELOG.md package.json package-lock.json
-          if [ ${{ needs.changelog.outputs.release-type }} != 'no-release' ]; then git tag v${{ steps.update-changelog.outputs.version }}; fi
 
       - name: Run status checks for release commit on temporary branch  # use temporary branch to enable pushing commits to this branch protected by required status checks
         uses: CasperWA/push-protected@v2.16.0  # 2.16 minimum is required to benefit from updated defaults
         with:
           token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
           branch: main
-          tags: true
           interval: 10  # seconds between checks
           pre_sleep: 15
           fail_fast: true
+
+      - name: Publish Git tag
+        if: needs.changelog.outputs.release-type != 'no-release'
+        run: |
+          git tag v${{ steps.update-changelog.outputs.version }}
+          git push --tags
 
       - name: Publish to NPM public repository
         if: needs.changelog.outputs.release-type != 'no-release'
@@ -50,7 +54,7 @@ jobs:
         with:
           token: ${{ secrets.NPMJS_ACCESS_TOKEN }}
 
-      - name: Create GitHub release
+      - name: Publish GitHub release
         if: needs.changelog.outputs.release-type != 'no-release'
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         uses: CasperWA/push-protected@v2.16.0  # 2.16 minimum is required to benefit from updated defaults
         with:
           token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
-          branch: main
+          branch: ${{ github.base_ref }}
           interval: 10  # seconds between checks
           pre_sleep: 15
           fail_fast: true
@@ -53,6 +53,7 @@ jobs:
         uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPMJS_ACCESS_TOKEN }}
+          dry-run: ${{ github.base_ref != 'main' }}
 
       - name: Publish GitHub release
         if: needs.changelog.outputs.release-type != 'no-release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           git config user.name "Open Terms Archive Release Bot"
           git config user.email "release-bot@opentermsarchive.org"
           git commit --message="Update changelog" CHANGELOG.md package.json package-lock.json
-          [ ${{ needs.changelog.outputs.release-type }} != 'no-release' ] && git tag v${{ steps.update-changelog.outputs.version }}
+          if [ ${{ needs.changelog.outputs.release-type }} != 'no-release' ]; then git tag v${{ steps.update-changelog.outputs.version }}; fi
 
       - name: Run status checks for release commit on temporary branch  # use temporary branch to enable pushing commits to this branch protected by required status checks
         uses: CasperWA/push-protected@v2.16.0  # 2.16 minimum is required to benefit from updated defaults

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,4 +61,4 @@ jobs:
         with:
           tag_name: v${{ steps.update-changelog.outputs.version }}
           body: ${{ steps.update-changelog.outputs.content }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Following #59, bring back ability to deploy versions that do not trigger a release.